### PR TITLE
Add index page with dark menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Exercise Menu</title>
+  <style>
+    body {
+      background-color: #0a0c10; /* dark bluish-gray nearly black */
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+    }
+    .menu {
+      position: absolute;
+      top: 20px;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+    }
+    .menu button {
+      padding: 10px 20px;
+      font-size: 1rem;
+      border: none;
+      background: #263238;
+      color: #fff;
+      cursor: pointer;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.3); /* drop shadow */
+    }
+    .menu button:hover {
+      background: #37474f;
+    }
+  </style>
+</head>
+<body>
+  <div class="menu">
+    <button>Run</button>
+    <button>Jump</button>
+    <button>Stretch</button>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a basic `index.html`
- use Helvetica-based fonts and a dark bluish-gray background
- keep the button menu at the top with drop shadows

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b2247da0c8320a0f1013b334855d8